### PR TITLE
refactor: cleanup varint generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,7 @@ impl Iterator for VarintBytes {
         } else {
             let ret = (self.0 & 0x7f) as u8;
             self.0 >>= 7;
-            Some(if self.0 != 0 {
-                ret | 0x80
-            } else {
-                ret
-            })
+            Some(if self.0 != 0 { ret | 0x80 } else { ret })
         }
     }
 }


### PR DESCRIPTION
This PR cleanups the varint generation (there was a lot of duplication in the previous iteration) and tests out how does this commit message go to the merge commit bors generates.